### PR TITLE
[codex] fix pool bond free balance

### DIFF
--- a/src/contexts/TransferOptions/index.tsx
+++ b/src/contexts/TransferOptions/index.tsx
@@ -45,7 +45,7 @@ export const TransferOptionsProvider = ({
   // `BalancesController`.
   const getTransferOptions = (address: MaybeAddress): TransferOptions => {
     const { maxLock } = getLocks(address);
-    const { free, frozen } = getBalance(address);
+    const { free } = getBalance(address);
     const { active, total, unlocking } = getLedger({ stash: address });
 
     // Calculate a forced amount of free balance that needs to be reserved to keep the account
@@ -59,12 +59,12 @@ export const TransferOptionsProvider = ({
     );
     // Free balance that can be transferred.
     const transferrableBalance = BigNumber.max(
-      freeMinusReserve.minus(frozen),
+      freeMinusReserve.minus(maxLock),
       0
     );
     // Free balance to pay for tx fees. Does not factor `feeReserve`.
     const balanceTxFees = BigNumber.max(
-      free.minus(edReserved).minus(frozen),
+      free.minus(edReserved).minus(maxLock),
       0
     );
     // Total amount unlocking and unlocked.

--- a/src/contexts/TxMeta/index.tsx
+++ b/src/contexts/TxMeta/index.tsx
@@ -73,7 +73,7 @@ export const TxMetaProvider = ({ children }: { children: ReactNode }) => {
   const pendingNoncesRef = useRef(pendingNonces);
 
   // Listen to balance updates for the tx sender.
-  const { getBalance, getEdReserved } = useActiveBalances({
+  const { getBalance, getEdReserved, getLocks } = useActiveBalances({
     accounts: [sender],
   });
 
@@ -158,8 +158,9 @@ export const TxMetaProvider = ({ children }: { children: ReactNode }) => {
   const senderBalances = getBalance(sender);
   useEffectIgnoreInitial(() => {
     const edReserved = getEdReserved(sender, existentialDeposit);
-    const { free, frozen } = senderBalances;
-    const balanceforTxFees = free.minus(edReserved).minus(frozen);
+    const { free } = senderBalances;
+    const { maxLock } = getLocks(sender);
+    const balanceforTxFees = free.minus(edReserved).minus(maxLock);
 
     setNotEnoughFunds(balanceforTxFees.minus(txFees).isLessThan(0));
   }, [txFees, sender, senderBalances]);

--- a/src/hooks/useBondGreatestFee/index.tsx
+++ b/src/hooks/useBondGreatestFee/index.tsx
@@ -15,12 +15,12 @@ interface Props {
 export const useBondGreatestFee = ({ bondFor }: Props) => {
   const { api } = useApi();
   const { activeAccount } = useActiveAccounts();
-  const { feeReserve, getTransferOptions } = useTransferOptions();
+  const { getTransferOptions } = useTransferOptions();
   const transferOptions = useMemo(
     () => getTransferOptions(activeAccount),
     [activeAccount]
   );
-  const { transferrableBalance } = transferOptions;
+  const { pool, transferrableBalance } = transferOptions;
 
   // store the largest possible tx fees for bonding.
   const [largestTxFee, setLargestTxFee] = useState<BigNumber>(new BigNumber(0));
@@ -39,7 +39,7 @@ export const useBondGreatestFee = ({ bondFor }: Props) => {
   // estimate the largest possible tx fee based on users free balance.
   const txLargestFee = async () => {
     const bond = BigNumber.max(
-      transferrableBalance.minus(feeReserve),
+      bondFor === 'pool' ? pool.totalPossibleBond : transferrableBalance,
       0
     ).toString();
 

--- a/src/library/BarChart/BondedChart.tsx
+++ b/src/library/BarChart/BondedChart.tsx
@@ -4,6 +4,7 @@
 import BigNumber from 'bignumber.js';
 import { useTranslation } from 'react-i18next';
 import { BarSegment } from 'library/BarChart/BarSegment';
+import { BarSegmentShowLabelThreshold } from 'library/BarChart/defaults';
 import { LegendItem } from 'library/BarChart/LegendItem';
 import { Bar, BarChartWrapper, Legend } from 'library/BarChart/Wrappers';
 import { useNetwork } from 'contexts/Network';
@@ -71,7 +72,15 @@ export const BondedChart = ({
         ) : null}
 
         {totalUnlocking.plus(active).isGreaterThan(0) ? (
-          <LegendItem dataClass="d4" label={t('free')} />
+          <LegendItem
+            dataClass="d4"
+            label={
+              freeToBond.isGreaterThan(0) &&
+              graphFree.isLessThan(BarSegmentShowLabelThreshold)
+                ? `${t('free')}: ${freeToBond.toFormat()} ${unit}`
+                : t('free')
+            }
+          />
         ) : null}
       </Legend>
       <Bar>

--- a/src/library/Form/Bond/BondFeedback.tsx
+++ b/src/library/Form/Bond/BondFeedback.tsx
@@ -49,7 +49,7 @@ export const BondFeedback = ({
   const availableBalance =
     bondFor === 'nominator'
       ? allTransferOptions.nominate.totalAdditionalBond
-      : allTransferOptions.transferrableBalance;
+      : allTransferOptions.pool.totalPossibleBond;
 
   // the default bond balance. If we are bonding, subtract tx fees from bond amount.
   const freeToBond = !disableTxFeeUpdate

--- a/src/modals/Accounts/index.tsx
+++ b/src/modals/Accounts/index.tsx
@@ -57,10 +57,11 @@ export const Accounts = () => {
     // Get amount required for existential deposit.
     const edReserved = getEdReserved(address, existentialDeposit);
     // Gets actual balance numbers.
-    const { free, frozen } = getBalance(address);
-    // Minus reserves and frozen balance from free to get transferrable.
+    const { free } = getBalance(address);
+    const { maxLock } = getLocks(address);
+    // Minus reserves and locked balance from free to get transferrable.
     return BigNumber.max(
-      free.minus(edReserved).minus(feeReserve).minus(frozen),
+      free.minus(edReserved).minus(feeReserve).minus(maxLock),
       0
     );
   };

--- a/src/modals/Bond/index.tsx
+++ b/src/modals/Bond/index.tsx
@@ -33,7 +33,7 @@ export const Bond = () => {
   const { activeAccount } = useActiveAccounts();
   const { pendingPoolRewards } = useActivePool();
   const { getSignerWarnings } = useSignerWarnings();
-  const { feeReserve, getTransferOptions } = useTransferOptions();
+  const { getTransferOptions } = useTransferOptions();
   const {
     setModalStatus,
     config: { options },
@@ -43,13 +43,12 @@ export const Bond = () => {
   const { bondFor } = options;
   const isStaking = bondFor === 'nominator';
   const isPooling = bondFor === 'pool';
-  const { nominate, transferrableBalance } = getTransferOptions(activeAccount);
+  const { nominate, pool } = getTransferOptions(activeAccount);
 
   const freeToBond = planckToUnitBn(
-    (bondFor === 'nominator'
+    bondFor === 'nominator'
       ? nominate.totalAdditionalBond
-      : transferrableBalance
-    ).minus(feeReserve),
+      : pool.totalPossibleBond,
     units
   );
 

--- a/src/pages/Overview/BalanceChart.tsx
+++ b/src/pages/Overview/BalanceChart.tsx
@@ -112,7 +112,9 @@ export const BalanceChart = () => {
   let fundsReserved = planckToUnitBn(edReserved.plus(feeReserve), units);
 
   const fundsFree = planckToUnitBn(
-    BigNumber.max(allTransferOptions.freeBalance.minus(fundsLockedPlank), 0),
+    inPool.isGreaterThan(0)
+      ? poolBondOpions.totalPossibleBond
+      : allTransferOptions.transferrableBalance,
     units
   );
 

--- a/src/pages/Pools/Home/ManageBond.tsx
+++ b/src/pages/Pools/Home/ManageBond.tsx
@@ -39,8 +39,13 @@ export const ManageBond = () => {
 
   const allTransferOptions = getTransferOptions(activeAccount);
   const {
-    pool: { active, totalUnlocking, totalUnlocked, totalUnlockChunks },
-    transferrableBalance,
+    pool: {
+      active,
+      totalUnlocking,
+      totalUnlocked,
+      totalUnlockChunks,
+      totalPossibleBond,
+    },
   } = allTransferOptions;
 
   const { state } = activePool?.bondedPool || {};
@@ -123,7 +128,7 @@ export const ManageBond = () => {
         active={planckToUnitBn(active, units)}
         unlocking={planckToUnitBn(totalUnlocking, units)}
         unlocked={planckToUnitBn(totalUnlocked, units)}
-        free={planckToUnitBn(transferrableBalance, units)}
+        free={planckToUnitBn(totalPossibleBond, units)}
         inactive={active.isZero()}
       />
     </>


### PR DESCRIPTION
## Summary

Fix pool-member free balance handling so accounts with pool-frozen funds can still bond extra from available free balance and submit the transaction.

## Root cause

The pool bond-extra flow reused generic transferable/frozen balance checks. For pool members, the frontend could subtract frozen funds too aggressively and conclude there was no VARA available, even when the account still had free balance available for pool bonding and transaction fees.

## Changes

- Use `pool.totalPossibleBond` for pool add-to-bond UI, validation, and fee estimation.
- Keep nominator add-to-bond on the nominator-specific amount.
- Align shared transferable and fee-balance calculations with `maxLock` instead of raw `frozen`.
- Align the account picker transferable display with the same lock basis.
- Show the pool-specific free amount on Pools and Overview for pool members.
- Show tiny free amounts in the bonded chart legend when the bar segment is too narrow for an inline label.

## Similar-bug audit

Checked all `getTransferOptions`, `transferrableBalance`, `freeBalance`, `balanceTxFees`, `totalPossibleBond`, `freeToBond`, and `notEnoughFunds` call sites. Remaining `frozen` usage is display-only in the Overview locked-balance section.

## Validation

- `yarn build` could not start in this checkout because Yarn reports the missing `node_modules` state file.
- Earlier `yarn install --immutable` stalled during fetch and was interrupted.
